### PR TITLE
Remove generated database files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ clean:
 	rm -rf source/reference/multi_objective/generated/
 	rm -rf source/reference/visualization/generated/
 	rm -rf source/tutorial/
+	rm -f tutorial/**/*.db


### PR DESCRIPTION
This PR removes generated database files which prevent the document build of tutorials. The corresponding change of optuna/optuna is included in https://github.com/optuna/optuna/pull/1722.