### PR TITLE
Add `imgconverter` plugin to render SVG images.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
+    "sphinx.ext.imgconverter",
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',


### PR DESCRIPTION
This PR corresponds to https://github.com/optuna/optuna/pull/2323.

It will resolve the following PDF build errors:

```console
! LaTeX Error: Cannot determine size of graphic in /home/docs/checkouts/readthe
docs.org/user_builds/optuna-zh-cn/checkouts/latest/source/_build/doctrees/image
s/f6661fbeae369352aec99b38ea299ee813f5e736/colab-badge.svg (no BoundingBox).

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.152 ...c99b38ea299ee813f5e736/colab-badge}.svg}}
```